### PR TITLE
Makefile: add DOCKER_BUILD_OPTS variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ WHOAMI ?= ${USER}
 # Docker binary
 DOCKER ?= docker
 
+# Addition arguments to docker build. (E.g. set --no-cache to invalidate the
+# current Docker cache if APT package information becomes outdated.)
+DOCKER_BUILD_OPTS ?=
+
 # What is a suitable name for the current git branch? Use it as the Docker tag.
 # If this is not a git repo, or there is no HEAD ref, use "latest" as a
 # fallback.
@@ -107,7 +111,7 @@ default: build
 
 .PHONY: image
 image:
-	$(DOCKER) build -t $(PROJECT_IMAGE) src
+	$(DOCKER) build -t $(PROJECT_IMAGE) $(DOCKER_BUILD_OPTS) src
 
 # We have to do this curious "double rule" here because the $(shell ...)
 # functions are evaluated at the *start* of the rule no matter where within the


### PR DESCRIPTION
Docker aggressively caches intermediate images so that repeated builds of the Docker image
are fast. In the case of apt-get update, however, this is dangerous since it means that the
package database is frozen at the point when the Docker image was originally created. Docker
provides a --no-cache option which will invalidate the intermediate image cache allowing
apt-get update to run again. This shouldn't be enabled by default as it massively increases
the time it takes an image to be built.

Add a DOCKER_BUILD_OPTS variable to the Makefile which can be used to append options to
calls to docker build on a case-by-case basis. One still needs to manually trigger a cache
invalidation but, as Dykstra said, there are only two hard problems in Computer Science:
naming things, cache invalidation and off-by-one errors.
