### PR TITLE
usb_cam_test: explicitly configure contrast and saturation

### DIFF
--- a/src/ros/surgery_launch/launch/usb_cam_test.launch
+++ b/src/ros/surgery_launch/launch/usb_cam_test.launch
@@ -1,5 +1,17 @@
 <launch>
-  <node pkg="usb_cam" type="usb_cam_node" name="usb_cam" />
+  <node pkg="usb_cam" type="usb_cam_node" name="usb_cam">
+    <!-- The usb_cam node hard-codes contrast and saturation to "32". For our
+         cameras this is not a good value; the image appears washed out and
+         indistinct. Explicitly set mid-range values. -->
+    <param name="contrast" value="128" />
+    <param name="saturation" value="128" />
+
+    <!-- The usb_cam node sets the focus value to something silly. Explicitly
+         disable auto-focus and set focus to "0" (aka "at infinity"). -->
+    <param name="autofocus" value="false" />
+    <param name="focus" value="0" />
+
+  </node>
   <node pkg="image_view" type="image_view" name="image_view">
     <remap from="image" to="usb_cam/image_raw" />
   </node>


### PR DESCRIPTION
In commit bosch-ros-pkg/usb_cam@b25c2938, contrast and saturation
parameters were added to usb_cam. Unfortunately these were hard-coded to
somewhat strange values. Both were turned down towards the bottom of the
range explaining the low-contrast, low-saturation images.

In the same commit, the default focus was set at a very near value
leading to blurry images.

The combination of these factors lead to the appearance of a very broken
webcam indeed.

Set the contrast, saturation and focus explicitly in the launch file and
add a comment explaining their presence. Launch files which use the
usb_cam node should probably explicitly set contrast and saturation from
now on.
