### PR TITLE
Dockerfile: make sure to upgrade after updating

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -24,6 +24,9 @@ RUN add-apt-repository ppa:openrave/release
 # Make sure package sources are up to date
 RUN apt-get -y update
 
+# Upgrade any installed packages
+RUN apt-get -y upgrade
+
 # Install additional packages
 RUN apt-get -y install ros-hydro-moveit-full \
     ros-hydro-dynamixel-motor ros-hydro-dynamixel-controllers \


### PR DESCRIPTION
Although apt-get update was called, upgrade did not follow it. This
lead to the strange situation of keeping some ROS packages at the
versions ineherited from the original image and some being the latest
ones.
