### PR TITLE
added additional end-effector link to define arm end point

### DIFF
--- a/src/ros/smart_arm_desc/effector_desc.xacro
+++ b/src/ros/smart_arm_desc/effector_desc.xacro
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+
+<robot name="smart_arm" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
+
+<macro name="end_effector" params="parent">
+
+
+  <joint name="effector_base_joint" type="fixed">
+    <parent link="${parent}"/>
+    <child link="effector_link"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+
+
+  <link name="effector_link">
+    <visual>
+      <geometry>
+        <cylinder length="0.165" radius="0.005"/>
+      </geometry>
+      <origin xyz="0.0825 0 0" rpy="0 1.57075 0"/>
+    </visual>
+  </link>
+
+<joint name="effector_tip_joint" type="fixed">
+    <parent link="effector_link"/>
+    <child link="effector_tip_link"/>
+    <origin xyz="0.165 0 0" rpy="0 0 0"/>
+  </joint>
+
+<link name = "effector_tip_link">
+</link>
+</macro>
+</robot>

--- a/src/ros/smart_arm_desc/robot_desc.xacro
+++ b/src/ros/smart_arm_desc/robot_desc.xacro
@@ -7,11 +7,13 @@
     
     <!-- Included URDF Files -->
     <include filename="$(find smart_arm_desc)/smart_arm_desc.xacro" />
-    
+    <include filename="$(find smart_arm_desc)/effector_desc.xacro" />
+
     <link name="world_link">
     </link>
     
     <smart_arm parent="world_link">
         <origin xyz="0 0 0" rpy="0 0 0" />
     </smart_arm>
+    <end_effector parent="arm_wrist_roll_link"/>
 </robot>


### PR DESCRIPTION
The latest PR adds a new end-effector file to define the point in space where the robot gripper closes. Changing the end effector macro in the robot_desc file means that alterations to the end effector can be made independently to the main arm description. 