### PR TITLE
Updated dockerfile to give correct permissions to Xdummy config file

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -72,6 +72,8 @@ RUN chown -R ros:ros /home/ros/.config/autostart
 
 # Copy X config
 ADD config/X11 /etc/X11
+# Ensure the X config is readable by all users
+RUN chmod oug+r /etc/X11/*
 
 # Copy local executables
 ADD config/bin/Xdummy /usr/bin/


### PR DESCRIPTION
Issue was initially identified when attempting to launch the Docker gui using make gui, which was resulting in a "permission denied" error. The error arose because not all users had been given access to the src/config/XDummy file, and so the permissions of this file were modified to allow access to any user using the Docker image.

Same as #35, but without a lot of extra baggage from earlier commits