### PR TITLE
Stream point cloud

### DIFF
--- a/src/ros/k2_client/CMakeLists.txt
+++ b/src/ros/k2_client/CMakeLists.txt
@@ -12,14 +12,20 @@ find_package(catkin REQUIRED
 	COMPONENTS
 	message_generation std_msgs geometry_msgs
 	roscpp rospy cv_bridge camera_info_manager
-	image_transport
+	image_transport pcl_ros
 )
 
 ## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
+#find_package(Boost REQUIRED COMPONENTS system)
 
 find_package(Jsoncpp REQUIRED)
 include_directories(${JSONCPP_INCLUDE_DIRS})
+
+# Find PCL dependencies
+find_package(PCL REQUIRED COMPONENTS common io)
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -120,6 +126,7 @@ add_executable(startBody src/k2_client/startBody.cpp)
 add_executable(startDepth src/k2_client/startDepth.cpp)
 add_executable(startIR src/k2_client/startIR.cpp)
 add_executable(startRGB src/k2_client/startRGB.cpp)
+add_executable(startPointCloud src/k2_client/startPointCloud.cpp)
 
 ## Declare a cpp executable
 # add_executable(k2_client_node src/k2_client_node.cpp)
@@ -132,6 +139,7 @@ add_dependencies(startBody k2_client_generate_messages_cpp)
 add_dependencies(startDepth k2_client_generate_messages_cpp)
 add_dependencies(startIR k2_client_generate_messages_cpp)
 add_dependencies(startRGB k2_client_generate_messages_cpp)
+add_dependencies(startPointCloud k2_client_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
 # target_link_libraries(k2_client_node
@@ -142,6 +150,7 @@ target_link_libraries(startBody ${catkin_LIBRARIES} ${JSONCPP_LIBRARIES})
 target_link_libraries(startDepth ${catkin_LIBRARIES} ${JSONCPP_LIBRARIES})
 target_link_libraries(startIR ${catkin_LIBRARIES} ${JSONCPP_LIBRARIES})
 target_link_libraries(startRGB ${catkin_LIBRARIES} ${JSONCPP_LIBRARIES})
+target_link_libraries(startPointCloud ${catkin_LIBRARIES} ${JSONCPP_LIBRARIES} ${PCL_LIBRARIES})
 
 #############
 ## Install ##

--- a/src/ros/k2_client/launch/k2_client.launch
+++ b/src/ros/k2_client/launch/k2_client.launch
@@ -6,5 +6,6 @@
 		<node name="startIR" pkg="k2_client" type="startIR"/>
 		<node name="startBody" pkg="k2_client" type="startBody"/>
 		<node name="startAudio" pkg="k2_client" type="startAudio"/>
+		<node name="startPointCloud" pkg="k2_client" type="startPointCloud" output="screen"/>
 		</group>
 </launch>

--- a/src/ros/k2_client/src/k2_client/startPointCloud.cpp
+++ b/src/ros/k2_client/src/k2_client/startPointCloud.cpp
@@ -1,0 +1,52 @@
+#include "k2_client.h"
+#include <pcl_ros/point_cloud.h>
+#include <pcl/point_types.h>
+using namespace std;
+
+typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
+
+int pointBufferSize = 2605056;
+int numberOfPoints = pointBufferSize / sizeof(float); // Hacky, much?
+int streamSize = pointBufferSize + sizeof(double);
+
+int main(int argC,char **argV)
+{
+	ros::init(argC,argV,"startPointCloud");
+	ros::NodeHandle n;
+
+	std::string serverAddress;
+	n.getParam("/serverNameOrIP",serverAddress);
+	Socket mySocket(serverAddress.c_str(),"9005",streamSize);
+
+	ros::Publisher pub = n.advertise<PointCloud>("point_cloud",1);
+
+	PointCloud::Ptr pc (new PointCloud);
+
+	pc->header.frame_id =  ros::this_node::getNamespace().substr(1,std::string::npos) + "/kinect_pcl";
+	while(ros::ok())
+	{
+		// TODO(Somhtr): change to ROS' logging API
+		cout << "Reading data..." << endl;
+		mySocket.readData();
+
+		// TODO(Somhtr): change to ROS' logging API
+		cout << "Copying data..." << endl;
+		float* pt_coords = reinterpret_cast<float*>(mySocket.mBuffer);
+		for(uint64_t idx=0; idx<numberOfPoints; idx+=3)
+		{
+			pc->push_back(pcl::PointXYZ(
+				pt_coords[idx], pt_coords[idx+1], pt_coords[idx+2]
+			));
+		}
+
+		double utcTime;
+		memcpy(&utcTime,&mySocket.mBuffer[pointBufferSize],sizeof(double));
+		pc->header.stamp = ros::Time(utcTime).toSec();
+
+		pub.publish(pc);
+		pc->clear();
+
+		ros::spinOnce();
+	}
+	return 0;
+}


### PR DESCRIPTION
Updated the Kinect 2 Client to stream point cloud data directly over the network.

The PR adds a new node "startPointCloud" which is launched and run in the same way as the other nodes in the K2_client package. The node accepts a bytestring from a network socket, deserializes it into a PCL PointXYZ point cloud, and then publishes to ros using the topic "/head/kinect2/point_cloud". 