### PR TITLE
k2_client: add k2_client_node target to CMakeLists.txt.

### DIFF
--- a/src/ros/k2_client/CMakeLists.txt
+++ b/src/ros/k2_client/CMakeLists.txt
@@ -143,6 +143,12 @@ target_link_libraries(startDepth ${catkin_LIBRARIES} ${JSONCPP_LIBRARIES})
 target_link_libraries(startIR ${catkin_LIBRARIES} ${JSONCPP_LIBRARIES})
 target_link_libraries(startRGB ${catkin_LIBRARIES} ${JSONCPP_LIBRARIES})
 
+# A "meta"-target which depends on all of the C++ programs
+add_custom_target(k2_client_nodes)
+add_dependencies(k2_client_nodes
+    startAudio startBody startDepth startIR startRGB startPointCloud
+)
+
 #############
 ## Install ##
 #############


### PR DESCRIPTION
The ``make build`` target has a ``CM_ARGS`` option which allows
specifying which target(s) to build. Add a k2_client_node target which
builds all of the k2_client nodes allowing for farser re-build.

Example:

```console
$ make delete_all_my_work; make build CM_ARGS=k2_client_nodes
```

(The use of CM_ARGS in general will probably speed many a ``make
build``...)